### PR TITLE
Fixed issue when rolling multiple dices + summon mount issue

### DIFF
--- a/totalRP3_Extended/inventory/inventory_effects.lua
+++ b/totalRP3_Extended/inventory/inventory_effects.lua
@@ -17,6 +17,8 @@
 --	limitations under the License.
 ----------------------------------------------------------------------------------
 
+-- Fixed the issue when trying to roll multiple dices and only rolling the first ones (Paul Corlay)
+
 local Globals, Events, Utils, EMPTY = TRP3_API.globals, TRP3_API.events, TRP3_API.utils, TRP3_API.globals.empty;
 local tonumber = tonumber;
 
@@ -153,7 +155,7 @@ TRP3_API.inventory.EFFECTS = {
 		end,
 		method = function(structure, cArgs, eArgs)
 			local serial = structure.getCArgs(cArgs);
-			eArgs.LAST = TRP3_API.slash.rollDices(TRP3_API.script.parseArgs(serial, eArgs));
+			eArgs.LAST = TRP3_API.slash.rollDices(strsplit(" ",TRP3_API.script.parseArgs(serial, eArgs)));
 		end,
 	},
 

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -17,6 +17,8 @@
 --	limitations under the License.
 ----------------------------------------------------------------------------------
 
+-- Fixed the "Summon Mount" effect (Paul Corlay)
+
 local assert, type, tostring, error, tonumber, pairs, unpack, wipe = assert, type, tostring, error, tonumber, pairs, unpack, wipe;
 local loc = TRP3_API.locale.getText;
 
@@ -329,7 +331,7 @@ local EFFECTS = {
 	["companion_summon_mount"] = {
 		method = function(structure, cArgs, eArgs)
 			local mountId = tonumber(cArgs[1] or 0);
-			SummonByID(mountId);
+			C_MountJournal.SummonByID(mountId);
 			eArgs.LAST = 0;
 		end,
 		securedMethod = function(structure, cArgs, eArgs)


### PR DESCRIPTION
Rolling multiple dices in an effect was only rolling the first type of dices in the string.