### PR TITLE
 Fixed the X & Y coordinates in Extended API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+Total-RP-3-Extended.iml
+.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-
-.idea/misc.xml
-.idea/modules.xml
-.idea/vcs.xml
-Total-RP-3-Extended.iml
-.idea/workspace.xml

--- a/totalRP3_Extended/misc/utils.lua
+++ b/totalRP3_Extended/misc/utils.lua
@@ -26,7 +26,7 @@ local sqrt, pow = math.sqrt, math.pow;
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 local function getUnitPositionSafe(unit)
-	local uX, uY, uZ, instanceID = UnitPosition(unit);
+	local uY, uX, uZ, instanceID = UnitPosition(unit);	-- It's not a typo.
 	return uX or 0, uY or 0, uZ or 0, instanceID or "0";
 end
 TRP3_API.extended.getUnitPositionSafe = getUnitPositionSafe;

--- a/totalRP3_Extended/misc/utils.lua
+++ b/totalRP3_Extended/misc/utils.lua
@@ -26,7 +26,7 @@ local sqrt, pow = math.sqrt, math.pow;
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 local function getUnitPositionSafe(unit)
-	local uY, uX, uZ, instanceID = UnitPosition(unit);	-- It's not a typo.
+	local uX, uY, uZ, instanceID = UnitPosition(unit);
 	return uX or 0, uY or 0, uZ or 0, instanceID or "0";
 end
 TRP3_API.extended.getUnitPositionSafe = getUnitPositionSafe;

--- a/totalRP3_Extended/script/script_operands.lua
+++ b/totalRP3_Extended/script/script_operands.lua
@@ -245,8 +245,8 @@ local OPERANDS = {
 		numeric = true,
 		codeReplacement = function(args)
 			local unitID = args[1] or "target";
-			local x = args[2] or 0;
-			local y = args[3] or 0;
+			local x = args[3] or 0;
+			local y = args[2] or 0;	-- Fix for the coordinates switch.
 			return ("unitDistancePoint(\"%s\", %s, %s)"):format(unitID, x, y);
 		end,
 		env = {

--- a/totalRP3_Extended_Tools/script/conditions/operands.lua
+++ b/totalRP3_Extended_Tools/script/conditions/operands.lua
@@ -313,7 +313,7 @@ local function unit_distance_point_init()
 		returnType = 0,
 		getText = function(args)
 			args = args or EMPTY;
-			return loc("OP_OP_DISTANCE_POINT_PREVIEW"):format(args[1] or "target", args[2] or 0, args[3] or 0);
+			return loc("OP_OP_DISTANCE_POINT_PREVIEW"):format(args[1] or "target", args[3] or 0, args[2] or 0);	-- See editor.load
 		end,
 		editor = editor,
 	});
@@ -329,14 +329,15 @@ local function unit_distance_point_init()
 		editor.y:SetText(string.format("%.2f", uY or 0));
 	end);
 
+	-- To make the coordinates fix compatible with old items, I'm just switching x and y in display and execution, saved data remains the same.
 	function editor.load(args)
 		editor.type:SetSelectedValue((args or EMPTY)[1] or "target");
-		editor.x:SetText((args or EMPTY)[2] or "0");
-		editor.y:SetText((args or EMPTY)[3] or "0");
+		editor.x:SetText((args or EMPTY)[3] or "0");
+		editor.y:SetText((args or EMPTY)[2] or "0");
 	end
 
 	function editor.save()
-		return {editor.type:GetSelectedValue() or "target", tonumber(strtrim(editor.x:GetText())) or 0, tonumber(strtrim(editor.y:GetText())) or 0};
+		return {editor.type:GetSelectedValue() or "target", tonumber(strtrim(editor.y:GetText())) or 0, tonumber(strtrim(editor.x:GetText())) or 0};
 	end
 
 	registerOperandEditor("unit_distance_me", {


### PR DESCRIPTION
Blizzard puts Y before X for some reason, had only fixed the calls for the specific coordinates, now fixed API as well.