### PR TITLE
Issue #63 : Offer to activate campaign when using effect from a disabled campaign

### DIFF
--- a/totalRP3_Extended/locale/locale_enEn.lua
+++ b/totalRP3_Extended/locale/locale_enEn.lua
@@ -172,6 +172,7 @@ TRP3_EXTENDED_LOCALE["enUS"] = {
 	QE_BUTTON = "Open quest log",
 	QE_NPC = "Campaign NPC",
 	QE_RESET_CONFIRM = "Reset this campaign?\n\nThis will lose all your progression for ALL the quests in this campaign.\n\nNote that you will keep all items you gained through this campaign.",
+	QE_AUTORESUME_CONFIRM = "An effect was called for the campaign |cff00ff00[%s]|r.\n\nActivate this campaign ?\n(If you already have an active campaign, it will be paused and your progress will be saved.)",
 	QE_ACTIONS_TYPE_LOOK = "Inspect",
 	QE_ACTIONS_TYPE_TALK = "Talk",
 	QE_ACTIONS_TYPE_LISTEN = "Listen",

--- a/totalRP3_Extended/quest/quest.lua
+++ b/totalRP3_Extended/quest/quest.lua
@@ -94,19 +94,17 @@ local function startQuest(campaignID, questID)
 	assert(campaignID, loc("ERROR_MISSING_ARG"):format("campaignID", "startQuest(campaignID, questID)"));
 	assert(questID, loc("ERROR_MISSING_ARG"):format("questID", "startQuest(campaignID, questID)"));
 
-	local playerQuestLog = TRP3_API.quest.getQuestLog();
-	if playerQuestLog.currentCampaign ~= campaignID then
-		Utils.message.displayMessage("|cffff0000[Error] Can't 'start quest' because current campaign is not " .. campaignID);
-		return 2;
-	end
-	local campaignLog = playerQuestLog[campaignID];
-	if not campaignLog then
-		Utils.message.displayMessage("|cffff0000[Error] Trying to 'start quest' from an unstarted campaign: " .. campaignID);
-		return 2;
-	end
 	if not TRP3_API.extended.classExists(campaignID, questID) then
 		Utils.message.displayMessage("|cffff0000[Error] 'start quest': Unknown quest: " .. campaignID .. " " .. questID);
 		return 2;
+	end
+	local playerQuestLog = TRP3_API.quest.getQuestLog();
+	if playerQuestLog.currentCampaign ~= campaignID then
+		TRP3_API.quest.activateCampaign(campaignID, false);
+	end
+	local campaignLog = playerQuestLog[campaignID];
+	if not campaignLog then
+		TRP3_API.quest.activateCampaign(campaignID, false);
 	end
 
 	Log.log("Starting quest " .. campaignID .. " " .. questID);

--- a/totalRP3_Extended/quest/quest.lua
+++ b/totalRP3_Extended/quest/quest.lua
@@ -292,32 +292,44 @@ local function goToStep(campaignID, questID, stepID)
 	assert(questID, loc("ERROR_MISSING_ARG"):format("questID", "TRP3_API.quest.goToStep(campaignID, questID, stepID)"));
 	assert(stepID, loc("ERROR_MISSING_ARG"):format("stepID", "TRP3_API.quest.goToStep(campaignID, questID, stepID)"));
 
-	local playerQuestLog = TRP3_API.quest.getQuestLog();
-	local campaignLog = playerQuestLog[campaignID];
-	local questLog = campaignLog.QUEST[questID];
-
-	if not questLog then
-		Utils.message.displayMessage("|cffff0000[Error] Trying to 'go to step' from an unstarted quest: " .. campaignID .. " " .. questID);
-		return 2;
-	end
 	if not TRP3_API.extended.classExists(campaignID, questID, stepID) then
 		Utils.message.displayMessage("|cffff0000[Error] 'go to step': Unknown quest step: " .. campaignID .. " " .. questID .. " " .. stepID);
 		return 2;
 	end
 
-	if playerQuestLog.currentCampaign ~= campaignID or not campaignLog then
+	local playerQuestLog = TRP3_API.quest.getQuestLog();
+	local campaignLog = playerQuestLog[campaignID];
+
+	if not campaignLog then
 		local campaignClass = getClass(campaignID);
 		local _, campaignName = getClassDataSafe(campaignClass);
 		local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
 		TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
 			TRP3_API.quest.activateCampaign(campaignID, false);
-			TRP3_API.quest.goToStepForReal(campaignID, questID, stepID);
+			TRP3_API.quest.goToStep(campaignID, questID, stepID);
 		end);
+		return 3;
 	else
-		TRP3_API.quest.goToStepForReal(campaignID, questID, stepID);
-	end
+		local questLog = campaignLog.QUEST[questID];
 
-	return 1;
+		if not questLog then
+			Utils.message.displayMessage("|cffff0000[Error] Trying to 'go to step' from an unstarted quest: " .. campaignID .. " " .. questID);
+			return 2;
+		end
+
+		if playerQuestLog.currentCampaign ~= campaignID then
+			local campaignClass = getClass(campaignID);
+			local _, campaignName = getClassDataSafe(campaignClass);
+			local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
+			TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
+				TRP3_API.quest.activateCampaign(campaignID, false);
+				TRP3_API.quest.goToStepForReal(campaignID, questID, stepID);
+			end);
+		else
+			TRP3_API.quest.goToStepForReal(campaignID, questID, stepID);
+		end
+		return 1;
+	end
 end
 TRP3_API.quest.goToStep = goToStep;
 
@@ -380,37 +392,49 @@ local function revealObjective(campaignID, questID, objectiveID)
 
 	local playerQuestLog = TRP3_API.quest.getQuestLog();
 	local campaignLog = playerQuestLog[campaignID];
-	local questLog = campaignLog.QUEST[questID];
 	local questClass = getClass(campaignID, questID);
 	local objectiveClass = questClass.OB[objectiveID];
 
-	if not questLog then
-		Utils.message.displayMessage("|cffff0000[Error] Trying to 'reveal objective' from an unstarted quest: " .. campaignID .. " " .. questID);
-		return 2;
-	end
 	if not TRP3_API.extended.classExists(campaignID, questID) then
 		Utils.message.displayMessage("|cffff0000[Error] 'reveal objective': Unknown quest: " .. campaignID .. " " .. questID);
 		return 2;
 	end
-
 	if not objectiveClass then
 		Utils.message.displayMessage("|cffff0000[Error] 'reveal objective': Unknown objective: " .. campaignID .. " " .. questID .. " " .. objectiveID);
 		return 2;
 	end
 
-	if playerQuestLog.currentCampaign ~= campaignID or not campaignLog then
+	if not campaignLog then
 		local campaignClass = getClass(campaignID);
 		local _, campaignName = getClassDataSafe(campaignClass);
 		local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
 		TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
 			TRP3_API.quest.activateCampaign(campaignID, false);
-			TRP3_API.quest.revealObjectiveForReal(campaignID, questID, objectiveID);
+			TRP3_API.quest.revealObjective(campaignID, questID, objectiveID);
 		end);
+		return 3;
 	else
-		TRP3_API.quest.revealObjectiveForReal(campaignID, questID, objectiveID);
-	end
+		local questLog = campaignLog.QUEST[questID];
 
-	return 1;
+		if not questLog then
+			Utils.message.displayMessage("|cffff0000[Error] Trying to 'reveal objective' from an unstarted quest: " .. campaignID .. " " .. questID);
+			return 2;
+		end
+
+		if playerQuestLog.currentCampaign ~= campaignID then
+			local campaignClass = getClass(campaignID);
+			local _, campaignName = getClassDataSafe(campaignClass);
+			local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
+			TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
+				TRP3_API.quest.activateCampaign(campaignID, false);
+				TRP3_API.quest.revealObjectiveForReal(campaignID, questID, objectiveID);
+			end);
+		else
+			TRP3_API.quest.revealObjectiveForReal(campaignID, questID, objectiveID);
+		end
+
+		return 1;
+	end
 end
 TRP3_API.quest.revealObjective = revealObjective;
 
@@ -450,11 +474,7 @@ local function markObjectiveDone(campaignID, questID, objectiveID)
 	local playerQuestLog = TRP3_API.quest.getQuestLog();
 
 	local campaignLog = playerQuestLog[campaignID];
-	local questLog = campaignLog.QUEST[questID];
-	if not questLog then
-		Utils.message.displayMessage("|cffff0000[Error] Trying to 'mark objective done' from an unstarted quest: " .. campaignID .. " " .. questID);
-		return 2;
-	end
+
 	if not TRP3_API.extended.classExists(campaignID, questID) then
 		Utils.message.displayMessage("|cffff0000[Error] 'mark objective done': Unknown quest: " .. campaignID .. " " .. questID);
 		return 2;
@@ -469,19 +489,35 @@ local function markObjectiveDone(campaignID, questID, objectiveID)
 		return 2;
 	end
 
-	if playerQuestLog.currentCampaign ~= campaignID or not campaignLog then
+	if not campaignLog then
 		local campaignClass = getClass(campaignID);
 		local _, campaignName = getClassDataSafe(campaignClass);
 		local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
 		TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
 			TRP3_API.quest.activateCampaign(campaignID, false);
-			TRP3_API.quest.markObjectiveDoneForReal(campaignID, questID, objectiveID);
+			TRP3_API.quest.markObjectiveDone(campaignID, questID, objectiveID);
 		end);
+		return 3;
 	else
-		TRP3_API.quest.markObjectiveDoneForReal(campaignID, questID, objectiveID);
-	end
+		local questLog = campaignLog.QUEST[questID];
+		if not questLog then
+			Utils.message.displayMessage("|cffff0000[Error] Trying to 'mark objective done' from an unstarted quest: " .. campaignID .. " " .. questID);
+			return 2;
+		end
 
-	return 1;
+		if playerQuestLog.currentCampaign ~= campaignID then
+			local campaignClass = getClass(campaignID);
+			local _, campaignName = getClassDataSafe(campaignClass);
+			local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
+			TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
+				TRP3_API.quest.activateCampaign(campaignID, false);
+				TRP3_API.quest.markObjectiveDoneForReal(campaignID, questID, objectiveID);
+			end);
+		else
+			TRP3_API.quest.markObjectiveDoneForReal(campaignID, questID, objectiveID);
+		end
+		return 1;
+	end
 end
 TRP3_API.quest.markObjectiveDone = markObjectiveDone;
 

--- a/totalRP3_Extended/quest/quest.lua
+++ b/totalRP3_Extended/quest/quest.lua
@@ -103,7 +103,10 @@ local function startQuest(campaignID, questID)
 	local campaignLog = playerQuestLog[campaignID];
 
 	if playerQuestLog.currentCampaign ~= campaignID or not campaignLog then
-		TRP3_API.popup.showConfirmPopup(loc("QE_RESET_CONFIRM"), function()
+		local campaignClass = getClass(campaignID);
+		local _, campaignName = getClassDataSafe(campaignClass);
+		local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
+		TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
 			TRP3_API.quest.activateCampaign(campaignID, false);
 			TRP3_API.quest.startQuestForReal(campaignID, questID);
 		end);
@@ -303,7 +306,10 @@ local function goToStep(campaignID, questID, stepID)
 	end
 
 	if playerQuestLog.currentCampaign ~= campaignID or not campaignLog then
-		TRP3_API.popup.showConfirmPopup(loc("QE_RESET_CONFIRM"), function()
+		local campaignClass = getClass(campaignID);
+		local _, campaignName = getClassDataSafe(campaignClass);
+		local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
+		TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
 			TRP3_API.quest.activateCampaign(campaignID, false);
 			TRP3_API.quest.goToStepForReal(campaignID, questID, stepID);
 		end);
@@ -393,7 +399,10 @@ local function revealObjective(campaignID, questID, objectiveID)
 	end
 
 	if playerQuestLog.currentCampaign ~= campaignID or not campaignLog then
-		TRP3_API.popup.showConfirmPopup(loc("QE_RESET_CONFIRM"), function()
+		local campaignClass = getClass(campaignID);
+		local _, campaignName = getClassDataSafe(campaignClass);
+		local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
+		TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
 			TRP3_API.quest.activateCampaign(campaignID, false);
 			TRP3_API.quest.revealObjectiveForReal(campaignID, questID, objectiveID);
 		end);
@@ -461,7 +470,10 @@ local function markObjectiveDone(campaignID, questID, objectiveID)
 	end
 
 	if playerQuestLog.currentCampaign ~= campaignID or not campaignLog then
-		TRP3_API.popup.showConfirmPopup(loc("QE_RESET_CONFIRM"), function()
+		local campaignClass = getClass(campaignID);
+		local _, campaignName = getClassDataSafe(campaignClass);
+		local autoResumeWarning = loc("QE_AUTORESUME_CONFIRM"):format(campaignName);
+		TRP3_API.popup.showConfirmPopup(autoResumeWarning, function()
 			TRP3_API.quest.activateCampaign(campaignID, false);
 			TRP3_API.quest.markObjectiveDoneForReal(campaignID, questID, objectiveID);
 		end);


### PR DESCRIPTION
Has been tested but a couple of points need to be discussed first : 
- While starting a quest from an unstarted campaign makes sense, I'm not sure about the other effects. They usually need to check if the quest has been started, which doesn't mean anything in an unstarted campaign, leading to an awkward situation where the player will agree to switch campaign but the effect might still throw an error afterwards. Maybe it should still return an error for those effects if the campaign was never started.
- The functions probably need some real names, let me know what makes sense. Also the prompt.