### PR TITLE
Variables evaluation on "Active campaign" level in items

### DIFF
--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -811,6 +811,8 @@ function TRP3_API.script.parseArgs(text, args)
 			return (args.event or EMPTY)[index] or capture;
 		elseif (args.custom or EMPTY)[capture] or ((args.object or EMPTY).vars or EMPTY)[capture] then
 			return (args.custom or EMPTY)[capture] or ((args.object or EMPTY).vars or EMPTY)[capture];
+		elseif ((TRP3_API.quest.getActiveCampaignLog() or EMPTY).vars or EMPTY)[capture] then
+			return ((TRP3_API.quest.getActiveCampaignLog() or EMPTY).vars or EMPTY)[capture];
 		elseif TRP3_API.extended.classExists(capture) then
 			return TRP3_API.inventory.getItemLink(TRP3_API.extended.getClass(capture), capture);
 		end


### PR DESCRIPTION
Issue #100 (following recent comments) : https://wow.curseforge.com/projects/total-rp-3-extended/issues/100

Test was added right before the item ID check to account for possible conflict with backers database IDs.