### PR TITLE
Added ID replacement to the inner items copy function

### DIFF
--- a/totalRP3_Extended_Tools/inner/inner.lua
+++ b/totalRP3_Extended_Tools/inner/inner.lua
@@ -232,6 +232,7 @@ local function addInnerObject(type, self)
 				local class = getClass(id);
 				local template = {};
 				Utils.table.copy(template, class);
+				TRP3_API.extended.tools.replaceID(template, id, toolFrame.fullClassID .. TRP3_API.extended.ID_SEPARATOR .. innerID);
 				createInnerObject(innerID, type, template);
 				refresh();
 			end, type});

--- a/totalRP3_Extended_Tools/items/editor/quick.lua
+++ b/totalRP3_Extended_Tools/items/editor/quick.lua
@@ -137,11 +137,11 @@ local function onQuickCreatedFromList(classID, _)
 	end, nil, 1);
 end
 
-local function replaceID(dataToUpdate, oldID, newID)
+function TRP3_API.extended.tools.replaceID(dataToUpdate, oldID, newID)
 	if type(dataToUpdate) == "table" then
 		for key, value in pairs(dataToUpdate) do
 			if type(value) == "table" then
-				replaceID(value, oldID, newID);
+				TRP3_API.extended.tools.replaceID(value, oldID, newID);
 			elseif type(value) == "string" then
 				dataToUpdate[key] = value:gsub(oldID, newID);
 			end
@@ -330,7 +330,7 @@ function TRP3_API.extended.tools.initItemQuickEditor(ToolFrame)
 				SD = date("%d/%m/%y %H:%M:%S");
 				SB = Globals.player_id,
 			};
-			replaceID(copiedData, fromID, id);
+			TRP3_API.extended.tools.replaceID(copiedData, fromID, id);
 			local ID, _ = TRP3_API.extended.tools.createItem(copiedData, id);
 			TRP3_API.extended.tools.goToPage(ID);
 		end, TRP3_DB.types.ITEM});
@@ -360,7 +360,7 @@ function TRP3_API.extended.tools.initItemQuickEditor(ToolFrame)
 				SD = date("%d/%m/%y %H:%M:%S");
 				SB = Globals.player_id,
 			};
-			replaceID(copiedData, fromID, id);
+			TRP3_API.extended.tools.replaceID(copiedData, fromID, id);
 			local ID, _ = TRP3_API.extended.tools.createItem(copiedData, id);
 			TRP3_API.extended.tools.goToPage(ID);
 		end, TRP3_DB.types.CAMPAIGN});


### PR DESCRIPTION
This came to me while looking at issue 20. While it isn't a complete answer to it, it should make copying to inner items easier.